### PR TITLE
feat: update tests and cache to fit multi-fids querying

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -141,24 +141,19 @@ describe("main cache", () => {
 
   test("should use cache for getUsersByFid", async () => {
     mockService.getUsersByFid.mockResolvedValueOnce({
-      data: mockUser,
+      data: [mockUser, mockUser],
       error: null,
     });
 
     // First call should hit the service
-    const result1 = await sdk.getUsersByFid([mockUser.fid]);
-    expect(result1.data).toEqual(mockUser);
+    const result1 = await sdk.getUsersByFid([mockUser.fid, mockUser.fid]);
+    expect(result1.data).toEqual([mockUser, mockUser]);
     expect(mockService.getUsersByFid).toHaveBeenCalledTimes(1);
 
     // Second call should use cache
-    const result2 = await sdk.getUsersByFid([mockUser.fid]);
-    expect(result2.data).toEqual(mockUser);
+    const result2 = await sdk.getUsersByFid([mockUser.fid, mockUser.fid]);
+    expect(result2.data).toEqual([mockUser, mockUser]);
     expect(mockService.getUsersByFid).toHaveBeenCalledTimes(1); // Still 1, not 2
-
-    // Second call should use cache
-    const result3 = await sdk.getUserByUsername(mockUser.username);
-    expect(result3.data).toEqual(mockUser);
-    expect(mockService.getUserByUsername).not.toBeCalled(); // Still 1, not 2
   });
 
   test("should use cache for getUserByUsername", async () => {
@@ -176,11 +171,6 @@ describe("main cache", () => {
     const result2 = await sdk.getUserByUsername(mockUser.username);
     expect(result2.data).toEqual(mockUser);
     expect(mockService.getUserByUsername).toHaveBeenCalledTimes(1); // Still 1, not 2
-
-    // Third call with fid should still use cache
-    const result3 = await sdk.getUsersByFid([mockUser.fid]);
-    expect(result3.data).toEqual(mockUser);
-    expect(mockService.getUsersByFid).not.toBeCalled();
   });
 
   test("should use cache for getCastByHash", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -243,8 +243,8 @@ class uniFarcasterSdk implements Omit<Service, "name" | "customQuery"> {
     );
     const { data } = result;
     if (data) {
-      //First params is the fid or username and we don't want to add that since we would get that from data
-      const setParams = type === "custom" ? params : params.slice(1);
+      //First params is the either hash or url and we don't want to add that since we would get that from data
+      const setParams = type === "cast" ? params.slice(1) : params;
       this.cache.set(type, data, setParams);
     }
     return result;
@@ -309,7 +309,7 @@ class uniFarcasterSdk implements Omit<Service, "name" | "customQuery"> {
   }
 
   public async getUsersByFid(fids: number[], viewerFid: number = DEFAULTS.fid) {
-    const res = (await this.withCache("user", "getUsersByFid", [
+    const res = (await this.withCache("fid", "getUsersByFid", [
       fids,
       viewerFid,
     ])) as DataOrError<User[]>;
@@ -320,7 +320,7 @@ class uniFarcasterSdk implements Omit<Service, "name" | "customQuery"> {
     username: string,
     viewerFid: number = DEFAULTS.fid,
   ) {
-    const res = await this.withCache("user", "getUserByUsername", [
+    const res = await this.withCache("username", "getUserByUsername", [
       username,
       viewerFid,
     ]);

--- a/src/lib/cache.test.ts
+++ b/src/lib/cache.test.ts
@@ -44,15 +44,23 @@ describe("cache", () => {
     cache = new Cache();
   });
 
-  test("should set and get user data", () => {
+  test("should set and get user data by fid", () => {
     const user: User = dummyUser;
 
-    cache.set("user", user, [dummyViewerFid]);
+    cache.set("fid", [user, user], [[user.fid, user.fid], dummyViewerFid]);
 
-    const cachedUserByFid = cache.get("user", [user.fid, dummyViewerFid]);
-    expect(cachedUserByFid).toEqual(user);
+    const cachedUserByFid = cache.get("fid", [
+      [user.fid, user.fid],
+      dummyViewerFid,
+    ]);
+    expect(cachedUserByFid).toEqual([user, user]);
+  });
+  test("should set and get user data by username", () => {
+    const user: User = dummyUser;
 
-    const cachedUserByUsername = cache.get("user", [
+    cache.set("username", user, [user.username, dummyViewerFid]);
+
+    const cachedUserByUsername = cache.get("username", [
       user.username,
       dummyViewerFid,
     ]);
@@ -71,8 +79,10 @@ describe("cache", () => {
   });
 
   test("should return null for non-existent data", () => {
-    const nonExistentUser = cache.get("user", ["nonexistent"]);
+    const nonExistentUser = cache.get("username", ["nonexistent"]);
     expect(nonExistentUser).toBeNull();
+    const nonExistentUser2 = cache.get("fid", [[124], 213144]);
+    expect(nonExistentUser2).toBeNull();
 
     const nonExistentCast = cache.get("cast", ["nonexistent"]);
     expect(nonExistentCast).toBeNull();
@@ -106,12 +116,15 @@ describe("cache with custom TTL", () => {
     const cache = new Cache({ ttl: 0 });
     const user: User = dummyUser;
 
-    cache.set("user", user, [dummyViewerFid]);
+    cache.set("username", user, [user.username, dummyViewerFid]);
 
-    const cachedUserByFid = cache.get("user", [user.fid, dummyViewerFid]);
+    const cachedUserByFid = cache.get("username", [
+      user.username,
+      dummyViewerFid,
+    ]);
     expect(cachedUserByFid).toBeNull();
 
-    const cachedUserByUsername = cache.get("user", [
+    const cachedUserByUsername = cache.get("username", [
       user.username,
       dummyViewerFid,
     ]);
@@ -123,12 +136,16 @@ describe("cache with custom TTL", () => {
     const cache = new Cache({ ttl: cacheTtl });
     const user: User = dummyUser;
 
-    cache.set("user", user, [dummyViewerFid]);
+    cache.set("fid", [user, user], [[user.fid, user.fid], dummyViewerFid]);
 
-    const cachedUserByFid = cache.get("user", [user.fid, dummyViewerFid]);
-    expect(cachedUserByFid).toEqual(user);
+    const cachedUserByFid = cache.get("fid", [
+      [user.fid, user.fid],
+      dummyViewerFid,
+    ]);
+    expect(cachedUserByFid).toEqual([user, user]);
 
-    const cachedUserByUsername = cache.get("user", [
+    cache.set("username", user, [user.username, dummyViewerFid]);
+    const cachedUserByUsername = cache.get("username", [
       user.username,
       dummyViewerFid,
     ]);
@@ -137,10 +154,13 @@ describe("cache with custom TTL", () => {
     // Wait for cache to expire
     await new Promise((resolve) => setTimeout(resolve, cacheTtl + 10));
 
-    const cachedUserByFid2 = cache.get("user", [user.fid, dummyViewerFid]);
+    const cachedUserByFid2 = cache.get("fid", [
+      [user.fid, user.fid],
+      dummyViewerFid,
+    ]);
     expect(cachedUserByFid2).toBeNull();
 
-    const cachedUserByUsername2 = cache.get("user", [
+    const cachedUserByUsername2 = cache.get("username", [
       user.username,
       dummyViewerFid,
     ]);

--- a/src/services/airstack/index.ts
+++ b/src/services/airstack/index.ts
@@ -162,6 +162,7 @@ export class airstackService implements Service {
       return { data, error };
     }
     const returnedData = data;
+    console.log(returnedData);
     return { data: this.getCastFromAirstackResult(returnedData), error: null };
   }
 


### PR DESCRIPTION
Previously, it was `getUserByFid`. But on usage, I realized, I often need to fetch by multiple fids so I updated the api impromptu.

This updates the caching behaviour to match to the new api `getUsersByFid` and also updates the tests