### PR TITLE
fix: airstack doesn't fetch replies

### DIFF
--- a/site/docs/pages/api-reference.mdx
+++ b/site/docs/pages/api-reference.mdx
@@ -82,6 +82,11 @@ const { data: cast, error } = await sdkInstance.getCastByUrl(
 );
 ```
 
+:::info
+All `getCastByUrl` queries use neynar service even when the active service is `airstack`.
+This is because there's currently an issue with Airstack where it can only fetch top level casts by URL. Replies return null.
+:::
+
 ## Custom Queries
 
 The above four methods are the most commonly needed from these services. However, there's a lot more you might need. So you can use either of these services directly

--- a/src/index.ts
+++ b/src/index.ts
@@ -339,7 +339,17 @@ class uniFarcasterSdk implements Omit<Service, "name" | "customQuery"> {
   }
 
   public async getCastByUrl(url: string, viewerFid: number = DEFAULTS.fid) {
+    /* Airstack only support top level casts by url so always only use neynar for query for this */
+    const currentService = this.activeService.name;
+
+    if (currentService === "airstack") {
+      this.activeService = this.createService("neynar");
+    }
     const res = await this.withCache("cast", "getCastByUrl", [url, viewerFid]);
+
+    if (currentService === "airstack") {
+      this.activeService = this.createService(currentService);
+    }
     return res;
   }
 }

--- a/src/services/airstack/index.test.ts
+++ b/src/services/airstack/index.test.ts
@@ -372,7 +372,7 @@ describe("airstackService", () => {
 
       const result = await service.getCastByUrl(
         "https://warpcast.com/testuser/0123456789",
-        456
+        456,
       );
 
       expect(result.error).toBeNull();
@@ -414,7 +414,7 @@ describe("airstackService", () => {
 
       const result = await service.getCastByUrl(
         "https://warpcast.com/testuser/0123456789",
-        456
+        456,
       );
 
       expect(result.data).toBeNull();

--- a/src/services/airstack/index.ts
+++ b/src/services/airstack/index.ts
@@ -16,13 +16,13 @@ export class airstackService implements Service {
     this.apiKey = apiKey;
     if (!apiKey) {
       throw new Error(
-        "Attempt to use an airstack API without first providing an api key"
+        "Attempt to use an airstack API without first providing an api key",
       );
     }
   }
 
   private getUserFromAirstackSociaslResult(
-    userDetails: AirstackUserQueryResult["Socials"]["Social"][0]
+    userDetails: AirstackUserQueryResult["Socials"]["Social"][0],
   ) {
     const userAddresses = this.getUserAddresses(userDetails.connectedAddresses);
     const convertedUser = {
@@ -41,7 +41,7 @@ export class airstackService implements Service {
   }
 
   private getUserAddresses(
-    userAddresses: { address: string; blockchain: string }[]
+    userAddresses: { address: string; blockchain: string }[],
   ) {
     const ethAddresses: string[] = [];
     const solAddresses: string[] = [];
@@ -61,7 +61,7 @@ export class airstackService implements Service {
       hash: castResult.FarcasterCasts.Cast[0]?.hash,
       url: castResult.FarcasterCasts.Cast[0]?.url,
       author: this.getUserFromAirstackSociaslResult(
-        castResult.FarcasterCasts.Cast[0]?.castedBy
+        castResult.FarcasterCasts.Cast[0]?.castedBy,
       ),
       userReactions: {
         likes: castResult.FarcasterCasts.Cast[0]?.numberOfLikes,
@@ -80,12 +80,12 @@ export class airstackService implements Service {
 
   async getUsersByFid(
     fids: number[],
-    viewerFid: number
+    viewerFid: number,
   ): Promise<DataOrError<User[]>> {
     const query = usersByFidQuery(fids, viewerFid);
     const { data, error } = await fetchQuery<AirstackUserQueryResult>(
       this.apiKey,
-      query
+      query,
     );
     if (error) {
       return { data, error };
@@ -95,11 +95,11 @@ export class airstackService implements Service {
     const users = returnedData.Socials.Social.map((user) => {
       const tempUser = this.getUserFromAirstackSociaslResult(user);
       const isFollowing = returnedData.Following.Following?.find(
-        (following) => following.followingProfileId === tempUser.fid.toString()
+        (following) => following.followingProfileId === tempUser.fid.toString(),
       );
 
       const isFollowedBy = returnedData.Followedby.Following?.find(
-        (following) => following.followerProfileId === tempUser.fid.toString()
+        (following) => following.followerProfileId === tempUser.fid.toString(),
       );
       return {
         ...tempUser,
@@ -115,7 +115,7 @@ export class airstackService implements Service {
 
   async getUserByUsername(
     username: string,
-    _viewerFid: number
+    _viewerFid: number,
   ): Promise<DataOrError<Omit<User, "viewerContext">>> {
     const query = userByUsernameQuery(username);
     const { data, error } = await fetchQuery<
@@ -133,7 +133,7 @@ export class airstackService implements Service {
       };
     return {
       data: this.getUserFromAirstackSociaslResult(
-        returnedData.Socials.Social[0]
+        returnedData.Socials.Social[0],
       ),
       error: null,
     };
@@ -141,12 +141,12 @@ export class airstackService implements Service {
 
   async getCastByHash(
     hash: string,
-    viewerFid: number
+    viewerFid: number,
   ): Promise<DataOrError<Cast>> {
     const query = castByHashQuery(hash, viewerFid);
     const { data, error } = await fetchQuery<AirstackCastQueryResult>(
       this.apiKey,
-      query
+      query,
     );
     if (error) {
       return { data, error };
@@ -162,12 +162,12 @@ export class airstackService implements Service {
 
   async getCastByUrl(
     url: string,
-    viewerFid: number
+    viewerFid: number,
   ): Promise<DataOrError<Cast>> {
     const query = castByUrlQuery(url, viewerFid);
     const { data, error } = await fetchQuery<AirstackCastQueryResult>(
       this.apiKey,
-      query
+      query,
     );
     if (error) {
       return { data, error };

--- a/src/services/airstack/index.ts
+++ b/src/services/airstack/index.ts
@@ -16,13 +16,13 @@ export class airstackService implements Service {
     this.apiKey = apiKey;
     if (!apiKey) {
       throw new Error(
-        "Attempt to use an airstack API without first providing an api key",
+        "Attempt to use an airstack API without first providing an api key"
       );
     }
   }
 
   private getUserFromAirstackSociaslResult(
-    userDetails: AirstackUserQueryResult["Socials"]["Social"][0],
+    userDetails: AirstackUserQueryResult["Socials"]["Social"][0]
   ) {
     const userAddresses = this.getUserAddresses(userDetails.connectedAddresses);
     const convertedUser = {
@@ -41,7 +41,7 @@ export class airstackService implements Service {
   }
 
   private getUserAddresses(
-    userAddresses: { address: string; blockchain: string }[],
+    userAddresses: { address: string; blockchain: string }[]
   ) {
     const ethAddresses: string[] = [];
     const solAddresses: string[] = [];
@@ -61,7 +61,7 @@ export class airstackService implements Service {
       hash: castResult.FarcasterCasts.Cast[0]?.hash,
       url: castResult.FarcasterCasts.Cast[0]?.url,
       author: this.getUserFromAirstackSociaslResult(
-        castResult.FarcasterCasts.Cast[0]?.castedBy,
+        castResult.FarcasterCasts.Cast[0]?.castedBy
       ),
       userReactions: {
         likes: castResult.FarcasterCasts.Cast[0]?.numberOfLikes,
@@ -80,12 +80,12 @@ export class airstackService implements Service {
 
   async getUsersByFid(
     fids: number[],
-    viewerFid: number,
+    viewerFid: number
   ): Promise<DataOrError<User[]>> {
     const query = usersByFidQuery(fids, viewerFid);
     const { data, error } = await fetchQuery<AirstackUserQueryResult>(
       this.apiKey,
-      query,
+      query
     );
     if (error) {
       return { data, error };
@@ -95,11 +95,11 @@ export class airstackService implements Service {
     const users = returnedData.Socials.Social.map((user) => {
       const tempUser = this.getUserFromAirstackSociaslResult(user);
       const isFollowing = returnedData.Following.Following?.find(
-        (following) => following.followingProfileId === tempUser.fid.toString(),
+        (following) => following.followingProfileId === tempUser.fid.toString()
       );
 
       const isFollowedBy = returnedData.Followedby.Following?.find(
-        (following) => following.followerProfileId === tempUser.fid.toString(),
+        (following) => following.followerProfileId === tempUser.fid.toString()
       );
       return {
         ...tempUser,
@@ -115,7 +115,7 @@ export class airstackService implements Service {
 
   async getUserByUsername(
     username: string,
-    _viewerFid: number,
+    _viewerFid: number
   ): Promise<DataOrError<Omit<User, "viewerContext">>> {
     const query = userByUsernameQuery(username);
     const { data, error } = await fetchQuery<
@@ -124,10 +124,16 @@ export class airstackService implements Service {
     if (error) {
       return { data, error };
     }
+
     const returnedData = data;
+    if (!returnedData.Socials.Social || returnedData.Socials.Social.length == 0)
+      return {
+        data: null,
+        error: { message: `user with username "${username}" not found` },
+      };
     return {
       data: this.getUserFromAirstackSociaslResult(
-        returnedData.Socials.Social[0],
+        returnedData.Socials.Social[0]
       ),
       error: null,
     };
@@ -135,12 +141,12 @@ export class airstackService implements Service {
 
   async getCastByHash(
     hash: string,
-    viewerFid: number,
+    viewerFid: number
   ): Promise<DataOrError<Cast>> {
     const query = castByHashQuery(hash, viewerFid);
     const { data, error } = await fetchQuery<AirstackCastQueryResult>(
       this.apiKey,
-      query,
+      query
     );
     if (error) {
       return { data, error };
@@ -156,12 +162,12 @@ export class airstackService implements Service {
 
   async getCastByUrl(
     url: string,
-    viewerFid: number,
+    viewerFid: number
   ): Promise<DataOrError<Cast>> {
     const query = castByUrlQuery(url, viewerFid);
     const { data, error } = await fetchQuery<AirstackCastQueryResult>(
       this.apiKey,
-      query,
+      query
     );
     if (error) {
       return { data, error };

--- a/src/services/airstack/index.ts
+++ b/src/services/airstack/index.ts
@@ -145,6 +145,11 @@ export class airstackService implements Service {
     if (error) {
       return { data, error };
     }
+    if (!data.FarcasterCasts?.Cast || data.FarcasterCasts.Cast.length == 0)
+      return {
+        data: null,
+        error: { message: `cast with hash "${hash}" not found` },
+      };
     const returnedData = data;
     return { data: this.getCastFromAirstackResult(returnedData), error: null };
   }
@@ -161,8 +166,13 @@ export class airstackService implements Service {
     if (error) {
       return { data, error };
     }
+
+    if (!data.FarcasterCasts?.Cast || data.FarcasterCasts.Cast.length == 0)
+      return {
+        data: null,
+        error: { message: `cast with url "${url}" not found` },
+      };
     const returnedData = data;
-    console.log(returnedData);
     return { data: this.getCastFromAirstackResult(returnedData), error: null };
   }
 


### PR DESCRIPTION
Airstack returns normally for top level casts but doesn't for replies. 
Reached out to the Airstack team and it's currently on consideration whether they fix it or not.

This PR makes getCastByUrl only use neynar service until this behaviour is fixed.